### PR TITLE
minior readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ This package is using [Browsershot](https://github.com/spatie/browsershot#requir
 
 You can install the package via composer:
 ```
-composer padocia/laravel-nova-pdf
+composer require padocia/laravel-nova-pdf
+```
+
+If you don't have the `puppeteer` on your project:
+```
+npm install puppeteer
 ```
 
 You can publish the default blade template :


### PR DESCRIPTION
Updated following: 

1. Fix missing `require` keyword for package install 
2. Update readme to include `npm install puppeteer` if the user doesn't have it
