### PR TITLE
Load tailwind style content directly from file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,16 @@
 {
-    "name": "monaye/laravel-nova-pdf",
+    "name": "padocia/laravel-nova-pdf",
     "description": "Generate Pdf from nova resources",
     "license": "MIT",
     "keywords": [
         "laravel",
         "nova"
     ],
+    "homepage": "https://github.com/padocia/laravel-nova-pdf",
     "authors": [
         {
+            "name": "Zakaria Tayeb Bey",
+            "email": "zakaria.tayebbey@gmail.com",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,13 @@
 {
-    "name": "padocia/laravel-nova-pdf",
+    "name": "monaye/laravel-nova-pdf",
     "description": "Generate Pdf from nova resources",
     "license": "MIT",
     "keywords": [
         "laravel",
         "nova"
     ],
-    "homepage": "https://github.com/padocia/laravel-nova-pdf",
     "authors": [
         {
-            "name": "Zakaria Tayeb Bey",
-            "email": "zakaria.tayebbey@gmail.com",
             "role": "Developer"
         }
     ],

--- a/src/Concerns/WithTailwind.php
+++ b/src/Concerns/WithTailwind.php
@@ -26,9 +26,9 @@ trait WithTailwind
      */
     protected function loadTailwind()
     {
-        if($this->tailwind)
-        {
-            $this->addStyle('laravel-nova-pdf-tailwind');
+        if ($this->tailwind) {
+            $path = __DIR__ . '/../../dist/css/tailwind.css';
+            $this->stylesContents[] = file_get_contents($path);
         }
 
         return $this;

--- a/src/NovaPdfServiceProvider.php
+++ b/src/NovaPdfServiceProvider.php
@@ -27,10 +27,6 @@ class NovaPdfServiceProvider extends ServiceProvider
         $this->app->booted(function () {
             $this->routes();
         });
-
-        Nova::serving(function (ServingNova $event) {
-            Nova::style('laravel-nova-pdf-tailwind', __DIR__.'/../dist/css/tailwind.css');
-        });
     }
 
     /**


### PR DESCRIPTION
With current logic. Tailwind CSS shipped with the LaravelNovaPdf is loaded to Nova and then later in the logic, LaravelNovaPdf gets the file path from the Nova so can load the file content for the export template. 

Since, the package style doesn't use anything other than PDF export, instead of registering Tailwind CSS to nova, load directly from the file. 
